### PR TITLE
fix: saas waning from usage

### DIFF
--- a/src/addons/dragAndDrop/styles.scss
+++ b/src/addons/dragAndDrop/styles.scss
@@ -1,4 +1,5 @@
-@import '../../sass/variables';
+@use 'sass:color';
+@use '../../sass/variables' as *;
 
 .rbc-addons-dnd {
   .rbc-addons-dnd-row-body {
@@ -14,9 +15,9 @@
 
   .rbc-addons-dnd-over {
     background-color: rgba(
-      red($date-selection-bg-color),
-      green($date-selection-bg-color),
-      blue($date-selection-bg-color),
+      color.red($date-selection-bg-color),
+      color.green($date-selection-bg-color),
+      color.blue($date-selection-bg-color),
       .3
     );
   }


### PR DESCRIPTION
This pull request updates the `src/addons/dragAndDrop/styles.scss` file to improve how Sass variables and color functions are imported and used. The changes modernize the Sass codebase and ensure compatibility with newer Sass module syntax.

**Sass module syntax update:**

* Switched from `@import` to `@use` for importing Sass modules, and updated the way variables are referenced by using `as *` to bring them into scope.
* Refactored color function usage to use the `color` namespace (e.g., `color.red`) instead of the global `red`, `green`, and `blue` functions, ensuring compatibility with the Sass module system.
