### PR TITLE
fix: update sass to version 1.80.0 and improve color handling in styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rollup": "^4.40.2",
     "rollup-plugin-clear": "^2.0.7",
     "rollup-plugin-dts": "^6.1.1",
-    "sass": "1.57.1",
+    "sass": "^1.80.0",
     "sass-loader": "^13.2.0",
     "semantic-release": "^20.0.2",
     "typescript": "^5.5.4",

--- a/src/addons/dragAndDrop/styles.scss
+++ b/src/addons/dragAndDrop/styles.scss
@@ -15,9 +15,9 @@
 
   .rbc-addons-dnd-over {
     background-color: rgba(
-      color.red($date-selection-bg-color),
-      color.green($date-selection-bg-color),
-      color.blue($date-selection-bg-color),
+      color.channel($date-selection-bg-color, "red", $space: rgb),
+      color.channel($date-selection-bg-color, "green", $space: rgb),
+      color.channel($date-selection-bg-color, "blue", $space: rgb),
       .3
     );
   }


### PR DESCRIPTION
This pull request updates the `sass` dependency to the latest version and refactors the way color channels are extracted in the drag and drop addon styles. These changes help ensure compatibility with newer versions of Sass and improve the maintainability of the style code.

Dependency update:

* Updated the `sass` package version in `package.json` from `1.57.1` to `^1.80.0` to support new features and maintain compatibility.

SCSS refactoring:

* Refactored the color channel extraction in `.rbc-addons-dnd-over` within `src/addons/dragAndDrop/styles.scss` to use `color.channel` instead of separate `color.red`, `color.green`, and `color.blue` functions, aligning with modern Sass practices.